### PR TITLE
Change color scheme to orange

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,7 +10,7 @@ const config: Config = {
     extend: {
       colors: {
         "dev-primary": "#1a1a1a",
-        "dev-accent": "#10b981", 
+        "dev-accent": "#f97316", 
         "dev-text": "#f8fafc",
         "dev-secondary": "#64748b",
         "dev-bg": "#0f172a",


### PR DESCRIPTION
Update the `dev-accent` color to orange in `tailwind.config.ts` to change the site's color scheme as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-7458c735-ce84-4227-8935-826230049817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7458c735-ce84-4227-8935-826230049817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

